### PR TITLE
Fix: allow spaces at the beginning and end of the description input

### DIFF
--- a/js/formulario.js
+++ b/js/formulario.js
@@ -195,7 +195,7 @@
   // --- Validate description input ---
   function validateDescripcionField() {
     const descripcionInput = form["descripcion"];
-    const descripcionValue = sanitizeHTML(descripcionInput.value.trim());
+    const descripcionValue = sanitizeHTML(descripcionInput.value);
 
     descripcionInput.value = descripcionValue;
 


### PR DESCRIPTION
### Summary

This pull request removes the `.trim()` call from the description field validation to allow users to include leading and trailing spaces in their text input.

### Why?

- Some users may intentionally add formatting or indentation (e.g., line breaks, spacing)
- Trimming the value could unintentionally remove meaningful content in user-generated descriptions

### Changes

- Removed `trim()` from `descripcionIsValid()` validation logic
- Kept all other validations (length, anti-XSS, suspicious patterns)
- No other fields were affected

---

This improves UX for users writing freeform text in the description field.